### PR TITLE
fix: use background propagation policy when deleting Jobs

### DIFF
--- a/internal/controller/rollouttest_controller.go
+++ b/internal/controller/rollouttest_controller.go
@@ -120,7 +120,7 @@ func (r *RolloutTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				_, _ = r.updateStatus(ctx, &rolloutTest, job, currentRevision)
 			}
 
-			if err := r.Delete(ctx, job); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
 				log.Error(err, "failed to delete job")
 				return ctrl.Result{}, err
 			}
@@ -207,7 +207,7 @@ func (r *RolloutTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			log.Info("Rollout canaryRevision changed, deleting old job",
 				"oldRevision", jobRevision,
 				"newRevision", rollout.Status.CanaryStatus.CanaryRevision)
-			if err := r.Delete(ctx, job); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil && !errors.IsNotFound(err) {
 				log.Error(err, "failed to delete old job")
 				return ctrl.Result{}, err
 			}


### PR DESCRIPTION
## Summary

- When the RolloutTest controller deletes a Job (on step change or canary revision change), it was calling `r.Delete(ctx, job)` without specifying a propagation policy. This defaulted to orphan deletion, leaving completed test pods behind indefinitely after the Job was removed.
- Added `client.PropagationPolicy(metav1.DeletePropagationBackground)` to both `r.Delete` calls so the garbage collector also cleans up child pods.

## Test plan

- [x] Existing unit tests pass (`make test`)
- [ ] Deploy to dev cluster and verify completed test pods are cleaned up after Job deletion