### PR TITLE
Issue #2

### DIFF
--- a/internal/controller/rolloutstepgate_controller.go
+++ b/internal/controller/rolloutstepgate_controller.go
@@ -246,8 +246,18 @@ func (r *RolloutStepGateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
-	// Evaluate test status
-	allPassed, anyFailedTests, failedTestName := r.evaluateTests(relevantTests)
+	// Evaluate test status.
+	// If no RolloutTests exist for this step and a positive step-bake-time is configured,
+	// treat tests as implicitly passed so bake-time can still gate auto-approval.
+	// Without bake-time, preserve the existing behavior of waiting for tests.
+	allPassed := false
+	anyFailedTests := false
+	failedTestName := ""
+	if len(tests) == 0 {
+		allPassed = bakeTime > 0
+	} else {
+		allPassed, anyFailedTests, failedTestName = r.evaluateTests(relevantTests)
+	}
 	anyFailed := anyFailedTests || bakeFailed
 
 	now := time.Now()

--- a/internal/controller/rolloutstepgate_controller_test.go
+++ b/internal/controller/rolloutstepgate_controller_test.go
@@ -866,6 +866,121 @@ var _ = Describe("RolloutStepGate Controller", func() {
 		})
 	})
 
+	Context("When step has no associated rollout tests", func() {
+		var namespace string
+		var rollout *kruiserolloutv1beta1.Rollout
+
+		BeforeEach(func() {
+			ctx := context.Background()
+
+			By("creating a unique namespace for the test")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-ns-",
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+			namespace = ns.Name
+
+			By("creating the Rollout with step-bake-time annotation and no RolloutTests")
+			rollout = &kruiserolloutv1beta1.Rollout{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-rollout-no-tests",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"rollout.kuberik.io/step-1-bake-time": "1m",
+					},
+				},
+				Spec: kruiserolloutv1beta1.RolloutSpec{
+					Strategy: kruiserolloutv1beta1.RolloutStrategy{
+						Canary: &kruiserolloutv1beta1.CanaryStrategy{
+							Steps: []kruiserolloutv1beta1.CanaryStep{
+								{
+									Replicas: &intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+									Pause: kruiserolloutv1beta1.RolloutPause{
+										Duration: func() *int32 { d := int32(3600); return &d }(),
+									},
+								},
+							},
+						},
+					},
+					WorkloadRef: kruiserolloutv1beta1.ObjectRef{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "test-deployment",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, rollout)).To(Succeed())
+
+			By("setting rollout status to step 1 paused")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout-no-tests", Namespace: namespace}, rollout)).To(Succeed())
+			if rollout.Status.CanaryStatus == nil {
+				rollout.Status.CanaryStatus = &kruiserolloutv1beta1.CanaryStatus{}
+			}
+			rollout.Status.CanaryStatus.CurrentStepIndex = 1
+			rollout.Status.CanaryStatus.CanaryRevision = "v1"
+			rollout.Status.CanaryStatus.CurrentStepState = "StepPaused"
+			Expect(k8sClient.Status().Update(ctx, rollout)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			ctx := context.Background()
+			By("Cleaning up the test namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+		})
+
+		It("should wait for step-bake-time and then auto-approve", func() {
+			ctx := context.Background()
+			controllerReconciler := &RolloutStepGateReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Reconciling for the first time - should mark ready and wait for bake-time")
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-rollout-no-tests",
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 30*time.Second), "should requeue near bake-time when no tests are configured")
+
+			By("Verifying step-ready annotation is set and rollout is still paused")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout-no-tests", Namespace: namespace}, rollout)).To(Succeed())
+			readyAt, exists := rollout.Annotations["internal.rollout.kuberik.io/step-1-ready-at"]
+			Expect(exists).To(BeTrue(), "ready-at annotation should be set when step has no associated tests")
+			Expect(readyAt).NotTo(BeEmpty())
+			Expect(rollout.Spec.Strategy.Canary.Steps[0].Pause.Duration).NotTo(BeNil())
+			Expect(*rollout.Spec.Strategy.Canary.Steps[0].Pause.Duration).To(BeNumerically(">", 0), "step should stay paused until bake-time elapses")
+
+			By("Setting ready-at in the past so bake-time is elapsed")
+			pastReadyAt := time.Now().Add(-2 * time.Minute).Format(time.RFC3339)
+			rollout.Annotations["internal.rollout.kuberik.io/step-1-ready-at"] = pastReadyAt
+			Expect(k8sClient.Update(ctx, rollout)).To(Succeed())
+
+			By("Reconciling again - should auto-approve and unpause the step")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-rollout-no-tests",
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying step was unpaused")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout-no-tests", Namespace: namespace}, rollout)).To(Succeed())
+			Expect(rollout.Spec.Strategy.Canary.Steps[0].Pause.Duration).NotTo(BeNil())
+			Expect(*rollout.Spec.Strategy.Canary.Steps[0].Pause.Duration).To(Equal(int32(0)))
+		})
+	})
+
 	Context("When kuberik Rollout bake status is checked", func() {
 		var namespace string
 		var kruiseRollout *kruiserolloutv1beta1.Rollout


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes issue #2 by ensuring bake-time annotations are respected for rollout steps that have no associated rollout tests.

The previous `evaluateTests()` logic treated zero tests as "not ready," which caused steps with a configured bake-time but no `RolloutTests` to remain paused indefinitely, ignoring the bake-time. This change distinguishes between "no tests configured for this step" (which should respect bake-time) and "tests exist but aren't ready."

---
<p><a href="https://cursor.com/agents/bc-ec49d1fe-109b-48f0-b98e-fb84378979c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec49d1fe-109b-48f0-b98e-fb84378979c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->