### PR TITLE
fix: apply retry side-effects unconditionally and preserve step-ready-at

### DIFF
--- a/internal/controller/retry_test.go
+++ b/internal/controller/retry_test.go
@@ -851,6 +851,98 @@ var _ = Describe("RolloutStepGate step deadline refresh on retry", func() {
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.kruiseRollout.Name, Namespace: f.ns}, second)).To(Succeed())
 		Expect(second.Annotations[stepStartedAtKey]).To(Equal(secondRetry.Format(time.RFC3339)))
 	})
+
+	// Regression for the hello-multi-staging flap: bakeFailed=true reconciles
+	// clear Stalled via the "rollout is healthy" else branch, leaving Stalled=False
+	// at retry time. stalledBefore then returns false and the retry-clear branch is
+	// skipped. step-started-at must still advance and stale Cancelled/Failed tests
+	// must still reset — otherwise the next bakeFailed=false reconcile re-stalls
+	// on the stale deadline, or evaluateTests treats Cancelled tests as
+	// stale-in-progress forever and the step never progresses.
+	It("refreshes step-started-at when Stalled=False at retry time", func() {
+		stalePast := time.Now().Add(-30 * time.Minute)
+		retryAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+		seedStaleDeadline(ctx, stalePast)
+		// No setStalled — the rollout has no Stalled=True condition (or a False one).
+		f.setKuberikRetry(ctx, retryAt, rolloutv1alpha1.RetryModeRetry)
+
+		_, err := f.reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: f.kruiseRollout.Name, Namespace: f.ns}})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &kruiserolloutv1beta1.Rollout{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.kruiseRollout.Name, Namespace: f.ns}, updated)).To(Succeed())
+		Expect(updated.Annotations[stepStartedAtKey]).To(Equal(retryAt.Format(time.RFC3339)))
+		Expect(updated.Annotations).NotTo(HaveKey(stepReadyAtKey))
+	})
+
+	// Regression for the bake-timer infinite loop: once step-started-at matches
+	// retryCutoff, subsequent reconciles must NOT clear a legitimately-set
+	// step-ready-at. Before this fix the function deleted ready-at whenever it
+	// was present, restarting the step-bake-time on every reconcile and looping
+	// forever in the "Step ready, waiting for step-bake-time" state.
+	It("does not clobber step-ready-at once step-started-at matches retryCutoff", func() {
+		retryAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.kruiseRollout.Name, Namespace: f.ns}, f.kruiseRollout)).To(Succeed())
+		if f.kruiseRollout.Annotations == nil {
+			f.kruiseRollout.Annotations = map[string]string{}
+		}
+		// Simulate post-retry steady state: step-started-at already at retryCutoff,
+		// step-ready-at set by the "Step ready for approval" branch.
+		readyAt := time.Now().Truncate(time.Second).Format(time.RFC3339)
+		f.kruiseRollout.Annotations[stepStartedAtKey] = retryAt.Format(time.RFC3339)
+		f.kruiseRollout.Annotations[stepReadyAtKey] = readyAt
+		f.kruiseRollout.Annotations["rollout.kuberik.io/step-1-ready-timeout"] = "10m"
+		// 1h bake-time keeps step paused so the post-bake auto-approval doesn't
+		// fire and unpause the step (which would legitimately clear ready-at).
+		f.kruiseRollout.Annotations["rollout.kuberik.io/step-1-bake-time"] = "1h"
+		f.kruiseRollout.Annotations["internal.rollout.kuberik.io/last-step-index"] = "1"
+		Expect(k8sClient.Update(ctx, f.kruiseRollout)).To(Succeed())
+		// Mark the test as Succeeded so allPassed=true and the "Step no longer ready"
+		// cleanup branch doesn't fire (which would legitimately clear step-ready-at).
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.rolloutTest.Name, Namespace: f.ns}, f.rolloutTest)).To(Succeed())
+		f.rolloutTest.Status.Phase = rolloutv1alpha1.RolloutTestPhaseSucceeded
+		f.rolloutTest.Status.ObservedCanaryRevision = "rev-1"
+		Expect(k8sClient.Status().Update(ctx, f.rolloutTest)).To(Succeed())
+		f.setKuberikRetry(ctx, retryAt, rolloutv1alpha1.RetryModeRetry)
+
+		_, err := f.reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: f.kruiseRollout.Name, Namespace: f.ns}})
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &kruiserolloutv1beta1.Rollout{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.kruiseRollout.Name, Namespace: f.ns}, updated)).To(Succeed())
+		Expect(updated.Annotations[stepStartedAtKey]).To(Equal(retryAt.Format(time.RFC3339)))
+		Expect(updated.Annotations[stepReadyAtKey]).To(Equal(readyAt), "step-ready-at must be preserved once step-started-at is aligned with retryCutoff")
+	})
+
+	It("resets a Cancelled test when Stalled=False at retry time", func() {
+		stalePast := time.Now().Add(-30 * time.Minute)
+		retryAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+		seedStaleDeadline(ctx, stalePast)
+		// Mark the test Cancelled with a transition timestamp pre-retry — matches
+		// hello-multi-staging where tests sat Cancelled for days before retry.
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.rolloutTest.Name, Namespace: f.ns}, f.rolloutTest)).To(Succeed())
+		f.rolloutTest.Status.Phase = rolloutv1alpha1.RolloutTestPhaseCancelled
+		f.rolloutTest.Status.Conditions = []metav1.Condition{{
+			Type:               rolloutv1alpha1.RolloutTestConditionFailed,
+			Status:             metav1.ConditionFalse,
+			Reason:             "JobCancelled",
+			Message:            "cancelled pre-retry",
+			LastTransitionTime: metav1.NewTime(stalePast),
+		}}
+		Expect(k8sClient.Status().Update(ctx, f.rolloutTest)).To(Succeed())
+		// No setStalled.
+		f.setKuberikRetry(ctx, retryAt, rolloutv1alpha1.RetryModeRetry)
+
+		_, err := f.reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: f.kruiseRollout.Name, Namespace: f.ns}})
+		Expect(err).NotTo(HaveOccurred())
+
+		updatedTest := &rolloutv1alpha1.RolloutTest{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.rolloutTest.Name, Namespace: f.ns}, updatedTest)).To(Succeed())
+		Expect(updatedTest.Status.Phase).To(Equal(rolloutv1alpha1.RolloutTestPhaseWaitingForStep))
+	})
 })
 
 var _ = Describe("RolloutTest stale-Stalled guard (retry cutoff)", func() {

--- a/internal/controller/rolloutstepgate_controller.go
+++ b/internal/controller/rolloutstepgate_controller.go
@@ -144,39 +144,44 @@ func (r *RolloutStepGateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		log.Error(err, "failed to fetch kuberik rollout retry timestamp")
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 	}
-	if retryCutoff != nil && r.stalledBefore(&rollout, retryCutoff) {
-		log.Info("Retry detected, resetting failed RolloutTests and clearing Stalled",
-			"retryCutoff", retryCutoff.Format(time.RFC3339),
-			"mode", retryMode)
-		if err := r.resetFailedTestsForStep(ctx, rollout.Namespace, rollout.Name, currentStepIndex, retryCutoff, retryMode); err != nil {
-			log.Error(err, "failed to reset failed RolloutTests during retry")
+	// Apply retry side-effects unconditionally when a retryCutoff exists. Must run
+	// outside the stalledBefore branch below: when bakeFailed=true drives the
+	// deadline-exceeded → clearStalled feedback loop (line 458 else), Stalled is
+	// False at the moment of retry visibility, so stalledBefore returns false and
+	// the retry branch is skipped. Without unconditional application, step-started-at
+	// stays stale (deadline immediately re-exceeded) and Cancelled/Failed tests
+	// never reset (step never progresses) — both defeat the retry. All three
+	// helpers below are idempotent on stable state:
+	//   - resetStepDeadlineForRetry: no-op when step-started-at already matches retryCutoff.
+	//   - resetFailedTestsForStep: only mutates tests where isStaleFailedTest is true;
+	//     post-reset phase is WaitingForStep/Skipped so the predicate is false.
+	//   - clearKuberikRetryModeAnnotation: no-op when the annotation is absent.
+	// Order is preserved from the original retry branch: tests reset before retry-mode
+	// annotation clear, so a transient failure leaves retry-mode set and the next
+	// reconcile re-enters this block to finish the cleanup.
+	if retryCutoff != nil {
+		if err := r.resetStepDeadlineForRetry(ctx, &rollout, currentStepIndex, retryCutoff); err != nil {
+			log.Error(err, "failed to refresh step deadline for retry")
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 		}
-		// Clear the rollouttest.kuberik.com/retry-mode annotation before clearing
-		// the Stalled condition. Doing it first means a transient failure here
-		// leaves the Stalled condition in place, so the next reconcile re-enters
-		// this branch and retries the cleanup. resetFailedTestsForStep is
-		// idempotent, so re-running it on already-reset tests is safe.
+		if err := r.resetFailedTestsForStep(ctx, rollout.Namespace, rollout.Name, currentStepIndex, retryCutoff, retryMode); err != nil {
+			log.Error(err, "failed to reset failed RolloutTests for retry")
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
+		}
 		if kuberikRollout != nil {
 			if err := clearKuberikRetryModeAnnotation(ctx, r.Client, kuberikRollout); err != nil {
 				log.Error(err, "failed to clear retry-mode annotation on kuberik Rollout")
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 			}
 		}
-		// Refresh the step deadline annotations to retryCutoff. Without this, a
-		// stale "step-started-at" (from before the retry) can push the step past
-		// its step-ready-timeout window the moment Stalled is cleared, so the
-		// next reconcile re-stalls with StepReadyTimeoutExceeded — defeating the
-		// retry. Using retryCutoff (not time.Now) gives concurrent reconciles a
-		// deterministic anchor.
-		if err := r.resetStepDeadlineForRetry(ctx, &rollout, currentStepIndex, retryCutoff); err != nil {
-			log.Error(err, "failed to refresh step deadline during retry")
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, err
-		}
-		// Refetch so clearStalledCondition sees the latest resource version.
 		if err := r.Get(ctx, req.NamespacedName, &rollout); err != nil {
 			return ctrl.Result{}, err
 		}
+	}
+	if retryCutoff != nil && r.stalledBefore(&rollout, retryCutoff) {
+		log.Info("Retry postdates Stalled condition, clearing it",
+			"retryCutoff", retryCutoff.Format(time.RFC3339),
+			"mode", retryMode)
 		if r.clearStalledCondition(&rollout) {
 			if err := r.Status().Update(ctx, &rollout); err != nil {
 				log.Error(err, "failed to clear Stalled condition during retry")
@@ -918,8 +923,11 @@ func stalledBefore(rollout *kruiserolloutv1beta1.Rollout, cutoff *metav1.Time) b
 
 // resetStepDeadlineForRetry writes the step-started-at annotation to retryCutoff
 // and clears step-ready-at so the step-ready-timeout window restarts after a
-// retry. Called only in the retry-detected branch; no-op when annotations are
-// already aligned.
+// retry. Called on every reconcile while a retryCutoff is recorded; no-op once
+// step-started-at already matches retryCutoff. ready-at is cleared only on the
+// transition (i.e. when we actually move step-started-at) — clearing it after
+// that would clobber a legitimate ready-at that the post-retry flow set when
+// the step finally cleared its tests, restarting the bake timer in a loop.
 func (r *RolloutStepGateReconciler) resetStepDeadlineForRetry(ctx context.Context, rollout *kruiserolloutv1beta1.Rollout, stepIndex int32, retryCutoff *metav1.Time) error {
 	if retryCutoff == nil {
 		return nil
@@ -930,8 +938,7 @@ func (r *RolloutStepGateReconciler) resetStepDeadlineForRetry(ctx context.Contex
 	startedAtKey := fmt.Sprintf(internalAnnotationStepStartedAtPrefix, stepIndex)
 	readyAtKey := fmt.Sprintf(internalAnnotationStepReadyAtPrefix, stepIndex)
 	desired := retryCutoff.Format(time.RFC3339)
-	_, hasReadyAt := rollout.Annotations[readyAtKey]
-	if rollout.Annotations[startedAtKey] == desired && !hasReadyAt {
+	if rollout.Annotations[startedAtKey] == desired {
 		return nil
 	}
 	rollout.Annotations[startedAtKey] = desired

--- a/internal/controller/rollouttest_controller.go
+++ b/internal/controller/rollouttest_controller.go
@@ -356,6 +356,13 @@ func (r *RolloutTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				rolloutTest.Status.Phase != rolloutv1alpha1.RolloutTestPhaseWaitingForStep {
 				rolloutTest.Status.Phase = rolloutv1alpha1.RolloutTestPhaseCancelled
 				rolloutTest.Status.JobName = ""
+				// Record the revision so the reset check at the top of the loop
+				// fires when a new canary revision appears (no job was ever created
+				// so ObservedCanaryRevision would otherwise stay empty and the reset
+				// would never trigger).
+				if currentRevision != "" {
+					rolloutTest.Status.ObservedCanaryRevision = currentRevision
+				}
 
 				message := "Test job creation skipped because rollout is stalled"
 				meta.SetStatusCondition(&rolloutTest.Status.Conditions, metav1.Condition{

--- a/internal/controller/rollouttest_controller_test.go
+++ b/internal/controller/rollouttest_controller_test.go
@@ -1154,6 +1154,24 @@ var _ = Describe("RolloutTest Controller", func() {
 				Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
 				Expect(readyCondition.Reason).To(Equal("JobCancelled"))
 				Expect(readyCondition.Message).To(ContainSubstring("skipped because rollout is stalled"))
+
+				By("Verifying ObservedCanaryRevision is stamped so a new revision can trigger reset")
+				Expect(rt.Status.ObservedCanaryRevision).To(Equal("v1"))
+
+				By("Simulating a new kruise rollout with a different canary revision")
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout", Namespace: namespace}, rollout)).To(Succeed())
+				rollout.Status.CanaryStatus.CanaryRevision = "v2"
+				rollout.Status.Conditions = nil
+				Expect(k8sClient.Status().Update(ctx, rollout)).To(Succeed())
+
+				By("Reconciling - should reset test to WaitingForStep")
+				_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(k8sClient.Get(ctx, typeNamespacedName, &rt)).To(Succeed())
+				Expect(rt.Status.Phase).To(Equal(rolloutv1alpha1.RolloutTestPhaseWaitingForStep))
+				Expect(rt.Status.ObservedCanaryRevision).To(BeEmpty())
+				Expect(rt.Status.Conditions).To(BeEmpty())
 			})
 
 			It("should cancel the test if rollout becomes stalled", func() {


### PR DESCRIPTION
The retry-clear branch was gated on `stalledBefore(retryCutoff)`. When a bakeFailed=true reconcile clears Stalled via the "rollout is healthy" else branch, Stalled is False at the moment of retry visibility — so stalledBefore returns false and the entire retry branch is skipped. step-started-at stays stale, the next bakeFailed=false reconcile immediately re-stalls on the yesterday-deadline, Cancelled tests never reset, and the rollout cannot progress. Observed live on hello-multi-staging where step-started-at remained at the previous day's value across many retries.

Move resetStepDeadlineForRetry, resetFailedTestsForStep, and clearKuberikRetryModeAnnotation out of the gate. All three are idempotent on stable state, so unconditional invocation while a retryCutoff is recorded is safe. clearStalledCondition stays gated since it only matters when Stalled was actually set.

resetStepDeadlineForRetry's "already aligned" guard previously also required step-ready-at to be absent. Under the new unconditional invocation pattern that clobbered every legitimate ready-at write — restarting step-bake-time on each reconcile and looping forever in "Step ready, waiting for step-bake-time". The ready-at clear only matters on the transition that moves step-started-at; once aligned, the no-op must preserve ready-at.