### PR TITLE
fix: treat same-second failure as pre-retry in stalledBefore and isStaleFailedTest

### DIFF
--- a/internal/controller/retry_test.go
+++ b/internal/controller/retry_test.go
@@ -916,6 +916,34 @@ var _ = Describe("RolloutStepGate step deadline refresh on retry", func() {
 		Expect(updated.Annotations[stepReadyAtKey]).To(Equal(readyAt), "step-ready-at must be preserved once step-started-at is aligned with retryCutoff")
 	})
 
+	// Regression: when failure and retry fall in the same wall-clock second,
+	// isStaleFailedTest used strict Before and returned false, so the test was
+	// never reset and the retry was effectively a no-op. The fix changes to <=.
+	It("resets a Cancelled test when failure timestamp equals retry cutoff (same-second race)", func() {
+		sameSecond := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+
+		seedStaleDeadline(ctx, sameSecond)
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.rolloutTest.Name, Namespace: f.ns}, f.rolloutTest)).To(Succeed())
+		f.rolloutTest.Status.Phase = rolloutv1alpha1.RolloutTestPhaseCancelled
+		f.rolloutTest.Status.Conditions = []metav1.Condition{{
+			Type:               rolloutv1alpha1.RolloutTestConditionFailed,
+			Status:             metav1.ConditionFalse,
+			Reason:             "JobCancelled",
+			Message:            "cancelled at same second as retry",
+			LastTransitionTime: metav1.NewTime(sameSecond),
+		}}
+		Expect(k8sClient.Status().Update(ctx, f.rolloutTest)).To(Succeed())
+		f.setKuberikRetry(ctx, sameSecond, rolloutv1alpha1.RetryModeRetry)
+
+		_, err := f.reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: f.kruiseRollout.Name, Namespace: f.ns}})
+		Expect(err).NotTo(HaveOccurred())
+
+		updatedTest := &rolloutv1alpha1.RolloutTest{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.rolloutTest.Name, Namespace: f.ns}, updatedTest)).To(Succeed())
+		Expect(updatedTest.Status.Phase).To(Equal(rolloutv1alpha1.RolloutTestPhaseWaitingForStep),
+			"test cancelled at the same second as retry must be reset (same-second = pre-retry)")
+	})
+
 	It("resets a Cancelled test when Stalled=False at retry time", func() {
 		stalePast := time.Now().Add(-30 * time.Minute)
 		retryAt := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
@@ -985,6 +1013,25 @@ var _ = Describe("RolloutTest stale-Stalled guard (retry cutoff)", func() {
 		updated := &rolloutv1alpha1.RolloutTest{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.rolloutTest.Name, Namespace: f.ns}, updated)).To(Succeed())
 		Expect(updated.Status.Phase).To(Equal(rolloutv1alpha1.RolloutTestPhasePending), "phase must not flip to Cancelled on stale stall")
+	})
+
+	// Regression: when stall and retry fall in the same wall-clock second,
+	// stalledBefore used strict Before and returned false, so the guard didn't
+	// fire and the test was cancelled. The fix changes to <=.
+	It("does NOT cancel a Pending test when Stalled timestamp equals retry cutoff (same-second race)", func() {
+		sameSecond := time.Now().Add(-1 * time.Minute)
+
+		f.setStalled(ctx, "KuberikRolloutBakeFailed", sameSecond)
+		f.setKuberikRetry(ctx, sameSecond, rolloutv1alpha1.RetryModeRetry)
+		markTestPhase(ctx, rolloutv1alpha1.RolloutTestPhasePending)
+
+		result, err := f.testReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: f.rolloutTest.Name, Namespace: f.ns}})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).NotTo(BeZero(), "should requeue while waiting for stepgate to clear stale stall")
+
+		updated := &rolloutv1alpha1.RolloutTest{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: f.rolloutTest.Name, Namespace: f.ns}, updated)).To(Succeed())
+		Expect(updated.Status.Phase).To(Equal(rolloutv1alpha1.RolloutTestPhasePending), "phase must not flip to Cancelled when stall and retry are the same second")
 	})
 
 	It("DOES cancel a Pending test when Stalled is fresh (postdates retry cutoff)", func() {

--- a/internal/controller/rolloutstepgate_controller.go
+++ b/internal/controller/rolloutstepgate_controller.go
@@ -915,7 +915,10 @@ func stalledBefore(rollout *kruiserolloutv1beta1.Rollout, cutoff *metav1.Time) b
 	}
 	for _, c := range rollout.Status.Conditions {
 		if c.Type == kruiserolloutv1beta1.RolloutConditionType("Stalled") && c.Status == corev1.ConditionTrue {
-			return c.LastTransitionTime.Time.Before(cutoff.Time)
+			// Use <= (not strict <): a stall that happened in the same wall-clock
+			// second as the retry is still a pre-retry stall — the user is retrying
+			// to escape from that state.
+			return !cutoff.Time.Before(c.LastTransitionTime.Time)
 		}
 	}
 	return false
@@ -1060,7 +1063,11 @@ func isStaleFailedTest(test *rolloutv1alpha1.RolloutTest, retryCutoff *metav1.Ti
 		// as fresh so we don't silently drop a real failure.
 		return false
 	}
-	return cond.LastTransitionTime.Time.Before(retryCutoff.Time)
+	// Use <= (not strict <): a failure in the same wall-clock second as the
+	// retry cutoff is still a pre-retry failure — the user is retrying to
+	// escape from that state. Strict Before caused retries to be no-ops when
+	// failure and retry timestamps fell in the same second.
+	return !retryCutoff.Time.Before(cond.LastTransitionTime.Time)
 }
 
 // getBakeFailureStatus checks if the rollout was deployed by kustomize and if the


### PR DESCRIPTION


Both guards used strict Before comparison. When the failure/stall timestamp and the retry cutoff fall in the same wall-clock second (observed on hello-world-dev: all three timestamps at 19:00:25Z), the guards returned false and the retry was a silent no-op — test stayed Cancelled, stall stayed set, evaluateTests treated it as a fresh failure.

Change to <= semantics (\!cutoff.Before(failure)) so a failure that happened at the same second as the retry is treated as pre-retry. Adds regression tests for both the stepgate reset path and the rollouttest stale-stall guard.