### PR TITLE
fix: keep RolloutTest Failed when bake also fails

### DIFF
--- a/internal/controller/rollouttest_controller.go
+++ b/internal/controller/rollouttest_controller.go
@@ -105,9 +105,13 @@ func (r *RolloutTestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// If CurrentStepIndex is no longer at the RolloutTest's StepIndex, or Rollout is Stalled, cancel the job
 		isStalled, stallReason := r.isRolloutStalled(&rollout)
 		bakeFailed := r.isBakeFailed(&rollout)
-		// If stalled due to TestFailed, do NOT cancel the job - let it be reported as Failed.
-		// Bake failure always cancels the job — tests are pointless once the bake has failed.
-		shouldCancel := (isStalled && stallReason != "RolloutTestFailed") || bakeFailed
+		// If stalled because a RolloutTest failed, do NOT cancel the job — the test
+		// failure is the meaningful result and must be preserved as Failed. This holds
+		// even when the bake has also failed: a broken deployment commonly fails both
+		// the test and the bake (KuberikBakeHealthy=False), and cancelling here would
+		// mask the real test failure by reporting Cancelled instead of Failed.
+		testFailedStall := isStalled && stallReason == "RolloutTestFailed"
+		shouldCancel := !testFailedStall && (isStalled || bakeFailed)
 		// Same stale-Stalled guard as the no-job branch: if a retry postdates the
 		// Stalled transition, the stepgate is unwinding the stall — don't delete
 		// the Job based on a condition that's about to be cleared.

--- a/internal/controller/rollouttest_controller_test.go
+++ b/internal/controller/rollouttest_controller_test.go
@@ -1240,6 +1240,110 @@ var _ = Describe("RolloutTest Controller", func() {
 				Expect(readyCondition.Message).To(ContainSubstring("bake failed"))
 			})
 
+			It("should preserve a Failed test as Failed (not Cancelled) when the bake also fails", func() {
+				// Regression: a broken deployment commonly fails both the RolloutTest
+				// and the bake. The stepgate sets Stalled=True (RolloutTestFailed) AND
+				// KuberikBakeHealthy=False on the same rollout. The bake-failure cancel
+				// path must not override the RolloutTestFailed carve-out, otherwise the
+				// real test failure is masked as Cancelled.
+				ctx := context.Background()
+				controllerReconciler := &RolloutTestReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+
+				By("Updating Rollout to step 1, paused, bake healthy")
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout", Namespace: namespace}, rollout)).To(Succeed())
+				rollout.Status.CurrentStepIndex = 1
+				if rollout.Status.CanaryStatus == nil {
+					rollout.Status.CanaryStatus = &kruiserolloutv1beta1.CanaryStatus{}
+				}
+				rollout.Status.CanaryStatus.CanaryRevision = "v1"
+				rollout.Status.CanaryStatus.CurrentStepState = "StepPaused"
+				rollout.Status.Conditions = nil
+				Expect(k8sClient.Status().Update(ctx, rollout)).To(Succeed())
+
+				By("Reconciling - should create job")
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+
+				var jobs batchv1.JobList
+				Expect(k8sClient.List(ctx, &jobs, client.InNamespace(namespace), client.MatchingLabels{"rollout-test": resourceName})).To(Succeed())
+				Expect(jobs.Items).To(HaveLen(1))
+				job := jobs.Items[0]
+
+				By("Setting the job to a failed (terminal) state")
+				now := metav1.Now()
+				job.Status.Failed = 3
+				job.Status.Active = 0
+				job.Status.StartTime = &now
+				job.Status.Conditions = []batchv1.JobCondition{
+					{
+						Type:               batchv1.JobFailureTarget,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      now,
+						LastTransitionTime: now,
+						Reason:             "BackoffLimitExceeded",
+						Message:            "Job has reached the specified backoff limit",
+					},
+					{
+						Type:               batchv1.JobFailed,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      now,
+						LastTransitionTime: now,
+						Reason:             "BackoffLimitExceeded",
+						Message:            "Job has reached the specified backoff limit",
+					},
+				}
+				Expect(k8sClient.Status().Update(ctx, &job)).To(Succeed())
+
+				By("Reconciling - test should become Failed")
+				_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+
+				var rt rolloutv1alpha1.RolloutTest
+				Expect(k8sClient.Get(ctx, typeNamespacedName, &rt)).To(Succeed())
+				Expect(rt.Status.Phase).To(Equal(rolloutv1alpha1.RolloutTestPhaseFailed))
+
+				By("Broken deployment: stepgate sets Stalled=RolloutTestFailed AND KuberikBakeHealthy=False")
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout", Namespace: namespace}, rollout)).To(Succeed())
+				rollout.Status.Conditions = []kruiserolloutv1beta1.RolloutCondition{
+					{
+						Type:               kruiserolloutv1beta1.RolloutConditionType("Stalled"),
+						Status:             corev1.ConditionTrue,
+						Reason:             "RolloutTestFailed",
+						Message:            "Rollout tests failed for current step (test test-rollouttest, step 1)",
+						LastTransitionTime: metav1.Now(),
+						LastUpdateTime:     metav1.Now(),
+					},
+					{
+						Type:               kruiserolloutv1beta1.RolloutConditionType("KuberikBakeHealthy"),
+						Status:             corev1.ConditionFalse,
+						Reason:             "BakeFailed",
+						Message:            "Kuberik Rollout has failed bake status",
+						LastTransitionTime: metav1.Now(),
+						LastUpdateTime:     metav1.Now(),
+					},
+				}
+				Expect(k8sClient.Status().Update(ctx, rollout)).To(Succeed())
+
+				By("Reconciling - failed test must stay Failed and the job must not be cancelled/deleted")
+				_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying the job was NOT deleted")
+				var stillThere batchv1.Job
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: namespace}, &stillThere)).To(Succeed())
+				Expect(stillThere.DeletionTimestamp.IsZero()).To(BeTrue())
+
+				By("Verifying RolloutTest phase is preserved as Failed (not Cancelled)")
+				Expect(k8sClient.Get(ctx, typeNamespacedName, &rt)).To(Succeed())
+				Expect(rt.Status.Phase).To(Equal(rolloutv1alpha1.RolloutTestPhaseFailed))
+				failedCondition := meta.FindStatusCondition(rt.Status.Conditions, "Failed")
+				Expect(failedCondition).NotTo(BeNil())
+				Expect(failedCondition.Status).To(Equal(metav1.ConditionTrue))
+			})
+
 			It("should not run the test if rollout is stalled", func() {
 				ctx := context.Background()
 				controllerReconciler := &RolloutTestReconciler{


### PR DESCRIPTION
## Summary

When a deployment is broken, the `RolloutTest` fails **and** the bake fails. The stepgate then sets both `Stalled=True (RolloutTestFailed)` and `KuberikBakeHealthy=False` on the same Kruise Rollout.

The job-exists cancellation logic computed:

```go
shouldCancel := (isStalled && stallReason != "RolloutTestFailed") || bakeFailed
```

The `|| bakeFailed` term overrode the existing `RolloutTestFailed` carve-out (introduced in #7's bake handling), so the failed test's job — and any retry job recreated for it — was cancelled. The test ended up reported as **Cancelled** instead of **Failed**, masking the real failure.

This was confirmed on the dev cluster: every recent cancellation in the controller logs was `"Kuberik rollout bake failed, cancelling job"` against tests whose step was stalled with `RolloutTestFailed`.

## Changes

- Don't cancel the job when the rollout is stalled because a `RolloutTest` failed (`stallReason == "RolloutTestFailed"`), even if the bake has also failed. Independent bake failures and non-test stalls (e.g. `StepReadyTimeoutExceeded`) still cancel as before.
- Add a regression test covering the combined `Stalled=RolloutTestFailed` + `KuberikBakeHealthy=False` case, asserting the test stays `Failed` and the job is not deleted.

## Test plan

- [x] `make test` passes (79/79 specs, incl. new regression test)
- [x] `go build ./...` and `go vet ./...` clean

Made with [Cursor](https://cursor.com)