### PR TITLE
fix: stop reporting cancelled rollout tests as failed

### DIFF
--- a/internal/controller/rolloutstepgate_controller.go
+++ b/internal/controller/rolloutstepgate_controller.go
@@ -347,6 +347,23 @@ func (r *RolloutStepGateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 	anyFailed := anyFailedTests || bakeFailed
 
+	// A test that is actively executing (job created / running) must be allowed to
+	// reach its own verdict. stepIsReady requires allPassed, so while a test runs
+	// the step is by definition "not ready" — if the ready-timeout were allowed to
+	// stall in that window, it would race the very test that gates readiness and
+	// (via the rollouttest controller's stall handling) cancel it mid-run, erasing
+	// the Failed verdict the test was about to produce. The test's own runtime is
+	// bounded by its Job (backoffLimit / activeDeadlineSeconds), which terminates
+	// it as Failed and stalls the rollout with the truthful RolloutTestFailed.
+	anyTestActive := false
+	for i := range relevantTests {
+		phase := relevantTests[i].Status.Phase
+		if phase == rolloutv1alpha1.RolloutTestPhaseRunning || phase == rolloutv1alpha1.RolloutTestPhasePending {
+			anyTestActive = true
+			break
+		}
+	}
+
 	now := time.Now()
 
 	// Get when the step started
@@ -461,7 +478,7 @@ func (r *RolloutStepGateReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, err
 			}
 		}
-	} else if !stepIsReady && !bakeFailed && now.After(deadline) {
+	} else if !stepIsReady && !bakeFailed && !anyTestActive && now.After(deadline) {
 		log.Info("Step ready-timeout exceeded, keeping paused", "step", currentStepIndex, "deadline", deadline)
 		message := fmt.Sprintf("Step %d step-ready-timeout (%v) exceeded at %v for canary %s. Rollout is paused and requires manual intervention.", currentStepIndex, readyTimeout, deadline.Format(time.RFC3339), currentRevision)
 		stalledModified, err := r.setStalledCondition(ctx, &rollout, currentStepIndex, "StepReadyTimeoutExceeded", message)
@@ -663,10 +680,12 @@ func (r *RolloutStepGateReconciler) getRolloutTestsForStep(ctx context.Context, 
 
 // evaluateTests checks the status of all tests.
 // Returns: (allPassed, anyFailed, failedTestName)
-// When retryCutoff is non-nil, a Failed/Cancelled test whose Failed condition
+// When retryCutoff is non-nil, a Failed test whose Failed condition
 // transitioned before the cutoff is treated as still in progress. This prevents
 // RolloutStepGate from re-stalling on stale pre-retry failures during the brief
 // window between the retry request and the eventual RolloutTest reset.
+// Cancelled tests are neither failed nor passed: they block progression like an
+// in-progress test but never produce the RolloutTestFailed stall reason.
 func (r *RolloutStepGateReconciler) evaluateTests(tests []rolloutv1alpha1.RolloutTest, retryCutoff *metav1.Time) (bool, bool, string) {
 	if len(tests) == 0 {
 		// No tests means we can't approve yet - wait for tests to be created
@@ -682,19 +701,31 @@ func (r *RolloutStepGateReconciler) evaluateTests(tests []rolloutv1alpha1.Rollou
 		// Only check Phase - it's the single source of truth
 		// This avoids race conditions with partial condition updates
 		switch test.Status.Phase {
-		case rolloutv1alpha1.RolloutTestPhaseFailed, rolloutv1alpha1.RolloutTestPhaseCancelled:
+		case rolloutv1alpha1.RolloutTestPhaseFailed:
 			if isStaleFailedTest(&test, retryCutoff) {
 				// Failure predates the retry; wait for the eventual reset.
 				anyInProgress = true
 				allPassed = false
 				continue
 			}
-			// Failed or Cancelled = test failed
 			anyFailed = true
 			allPassed = false
 			if failedTestName == "" {
 				failedTestName = test.Name
 			}
+		case rolloutv1alpha1.RolloutTestPhaseCancelled:
+			// A cancelled test has no verdict: it was interrupted (step advance,
+			// stall, bake failure) before finishing. It must not count as a failed
+			// test — stalls cancel running tests, so attributing the stall to the
+			// test it cancelled inverts cause and effect and reports the
+			// contradictory "Stalled: RolloutTestFailed" while the test itself says
+			// Cancelled. (Tests that were already failing when cancelled are
+			// recorded as Failed by the rollouttest controller and take the branch
+			// above.) It does not pass either: keep the step blocked under the
+			// stall's original reason until a retry resets the test or a new canary
+			// revision appears.
+			anyInProgress = true
+			allPassed = false
 		case rolloutv1alpha1.RolloutTestPhaseSucceeded, rolloutv1alpha1.RolloutTestPhaseSkipped:
 			// Test passed (Skipped counts as passing — user intentionally bypassed it).
 		default:

--- a/internal/controller/rolloutstepgate_controller_test.go
+++ b/internal/controller/rolloutstepgate_controller_test.go
@@ -181,6 +181,67 @@ var _ = Describe("RolloutStepGate Controller", func() {
 			Expect(result.Status).To(Equal(status.FailedStatus))
 		})
 
+		It("should NOT stall on ready-timeout while a test is actively running", func() {
+			// Regression: the step is "not ready" precisely because the test hasn't
+			// finished yet — stepIsReady requires allPassed. Stalling on the deadline
+			// in that window races the very test that gates readiness: the stall
+			// cancels the running job mid-flight, erasing the Failed verdict the test
+			// was about to produce (and the Cancelled test then can't explain the
+			// failure). The deadline must yield while a test is actively executing;
+			// the test's own Job limits bound its runtime and produce the truthful
+			// RolloutTestFailed stall when it fails.
+			ctx := context.Background()
+			controllerReconciler := &RolloutStepGateReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			By("Setting up Rollout at step 1, paused")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout", Namespace: namespace}, rollout)).To(Succeed())
+			if rollout.Status.CanaryStatus == nil {
+				rollout.Status.CanaryStatus = &kruiserolloutv1beta1.CanaryStatus{}
+			}
+			rollout.Status.CanaryStatus.CurrentStepIndex = 1
+			rollout.Status.CanaryStatus.CanaryRevision = "v1"
+			rollout.Status.CanaryStatus.CurrentStepState = "StepPaused"
+			Expect(k8sClient.Status().Update(ctx, rollout)).To(Succeed())
+
+			By("Setting up RolloutTest as actively Running")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollouttest", Namespace: namespace}, rolloutTest)).To(Succeed())
+			rolloutTest.Status.ObservedCanaryRevision = "v1"
+			rolloutTest.Status.Phase = rolloutv1alpha1.RolloutTestPhaseRunning
+			rolloutTest.Status.JobName = "test-rollouttest-job"
+			Expect(k8sClient.Status().Update(ctx, rolloutTest)).To(Succeed())
+
+			By("Setting started-at annotation to a time in the past (exceeding ready-timeout)")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout", Namespace: namespace}, rollout)).To(Succeed())
+			pastTime := time.Now().Add(-2 * time.Minute) // 2 minutes ago, ready-timeout is 1 minute
+			if rollout.Annotations == nil {
+				rollout.Annotations = make(map[string]string)
+			}
+			rollout.Annotations["internal.rollout.kuberik.io/step-1-started-at"] = pastTime.Format(time.RFC3339)
+			rollout.Annotations["internal.rollout.kuberik.io/last-step-index"] = "1"
+			Expect(k8sClient.Update(ctx, rollout)).To(Succeed())
+
+			By("Reconciling - deadline is exceeded but a test is running")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-rollout",
+					Namespace: namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying NO Stalled condition was set")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout", Namespace: namespace}, rollout)).To(Succeed())
+			for _, cond := range rollout.Status.Conditions {
+				if string(cond.Type) == "Stalled" {
+					Expect(cond.Status).NotTo(Equal(corev1.ConditionTrue),
+						"ready-timeout must not stall while a test is actively running")
+				}
+			}
+		})
+
 		It("should NOT timeout if step becomes ready before deadline", func() {
 			ctx := context.Background()
 			controllerReconciler := &RolloutStepGateReconciler{
@@ -386,7 +447,8 @@ var _ = Describe("RolloutStepGate Controller", func() {
 			rolloutTest.Status.ObservedCanaryRevision = "v1"
 			rolloutTest.Status.Phase = rolloutv1alpha1.RolloutTestPhaseCancelled
 			rolloutTest.Status.FailedPods = 2
-			// Cancelled tests have Failed condition = False but should be treated as failed
+			// Cancelled tests have Failed condition = False; they block progression
+			// (step must not become ready) but do not count as failed tests
 			rolloutTest.Status.Conditions = []metav1.Condition{
 				{
 					Type:               "Ready",
@@ -425,6 +487,19 @@ var _ = Describe("RolloutStepGate Controller", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "test-rollout", Namespace: namespace}, rollout)).To(Succeed())
 			_, exists := rollout.Annotations["internal.rollout.kuberik.io/step-1-ready-at"]
 			Expect(exists).To(BeFalse(), "readyAt should NOT be set when test is Cancelled")
+
+			By("Verifying the stall is NOT attributed to a failed test")
+			// Regression: a Cancelled test has no verdict — stalls cancel running
+			// tests, so attributing the stall to the cancelled test inverts cause and
+			// effect ("rollout failed because of failed test" while the test says
+			// Cancelled). A genuinely failing cancelled test is recorded as Failed by
+			// the rollouttest controller instead.
+			for _, cond := range rollout.Status.Conditions {
+				if string(cond.Type) == "Stalled" && cond.Status == corev1.ConditionTrue {
+					Expect(cond.Reason).NotTo(Equal("RolloutTestFailed"),
+						"Cancelled test must not produce the RolloutTestFailed stall reason")
+				}
+			}
 		})
 
 		It("should clear Stalled condition when within deadline", func() {


### PR DESCRIPTION
## Summary

Deterministic loop seen consistently in production (no race involved):

1. A test runs at its step; the step is not "ready" by definition until the test passes.
2. The test runs longer than `step-ready-timeout` → stepgate stalls with `StepReadyTimeoutExceeded`.
3. The stall makes the rollouttest controller cancel the running test job → test phase `Cancelled`.
4. `evaluateTests` counted `Cancelled` as failed → stepgate re-stalls with `RolloutTestFailed`.
5. End state every time: Rollout says "Rollout tests failed for current step" while the test says `Cancelled`.

### Changes (both in the stepgate, each severs the loop)

- **Ready-timeout yields to an actively running test.** The `step-ready-timeout` no longer fires while a test is `Running`/`Pending`, so it cannot cancel the very test that gates readiness (breaks 2→3). The test's runtime stays bounded by its Job (`backoffLimit`/`activeDeadlineSeconds`); a genuine test failure still stalls with `RolloutTestFailed`.
- **`Cancelled` is not `Failed`.** `evaluateTests` no longer counts `Cancelled` tests as failed (breaks step 4). A cancelled test has no verdict: it blocks progression like an in-progress test, so a stall keeps its truthful original reason (e.g. `StepReadyTimeoutExceeded`) instead of being rewritten to `RolloutTestFailed`.

## Test plan

- [x] `make test` passes (envtest)
- [x] New regression test: ready-timeout does not stall while a test is actively running
- [x] Extended test: a `Cancelled` test never produces a `RolloutTestFailed` stall reason
- [ ] Deploy to dev cluster and verify the Rollout message matches the actual stall cause